### PR TITLE
Include necessary header files to get compilation on OSX

### DIFF
--- a/Combinatorial/stability_louvain_LCL.cpp
+++ b/Combinatorial/stability_louvain_LCL.cpp
@@ -56,6 +56,8 @@ int gettimeofday (struct timeval *tp, void *tz)
 
 #ifdef __MAC__
 #include <sys/time.h>
+#include <unistd.h>
+#include <sys/types.h> 
 #endif
 
 using namespace std;

--- a/Normalised/stability_louvain_LNL.cpp
+++ b/Normalised/stability_louvain_LNL.cpp
@@ -57,6 +57,8 @@ int gettimeofday (struct timeval *tp, void *tz)
 
 #ifdef __MAC__
 #include <sys/time.h>
+#include <unistd.h>
+#include <sys/types.h> 
 #endif
 
 using namespace std;


### PR DESCRIPTION
Hi,

   There were some missing 'include' statements to get the library to compile on OSX (tested on 10.9, these are really basic stuff, so I wouldn't expect them to have changed in a while). Source: https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man2/getpid.2.html

Thanks,

Adrien
