### PR TITLE
change include of malloc.h in graph_binary.cpp files for MAC

### DIFF
--- a/Combinatorial/graph_binary.h
+++ b/Combinatorial/graph_binary.h
@@ -36,7 +36,7 @@
 #endif
 
 #ifdef __MAC__
-#include "/usr/include/sys/malloc.h"
+#include <malloc/malloc.h>
 #endif
 
 

--- a/Normalised/graph_binary.h
+++ b/Normalised/graph_binary.h
@@ -35,7 +35,7 @@
 #endif
 
 #ifdef __MAC__
-#include "/usr/include/sys/malloc.h"
+#include <malloc/malloc.h>
 #endif
 
 #define WEIGHTED   0


### PR DESCRIPTION
To install on my MAC I had to change the include of malloc.h in two header files. My system's configuration:

![screen shot 2015-05-18 at 13 31 19](https://cloud.githubusercontent.com/assets/2342606/7680815/3cba6544-fd62-11e4-8953-dfe785f8f99a.png)
